### PR TITLE
De-ambiguification of isanan

### DIFF
--- a/src/sprout/process.cc
+++ b/src/sprout/process.cc
@@ -88,12 +88,12 @@ void Process::evolve( const double time )
 								* ( _gaussian.cdf( new_pmf.sample_ceil( new_rate ) - old_rate )
 								    - _gaussian.cdf( new_pmf.sample_floor( new_rate ) - old_rate ) );
 
-							      assert( !isnan( zfactor ) );
-							      assert( !isnan( old_prob ) );
-							      assert( !isnan( new_rate ) );
-							      assert( !isnan( old_rate ) );
-							      assert( !isnan( _gaussian.cdf( new_pmf.sample_ceil( new_rate ) - old_rate ) ) );
-							      assert( !isnan( _gaussian.cdf( new_pmf.sample_floor( new_rate ) - old_rate ) ) );
+							      assert( !std::isnan( zfactor ) );
+							      assert( !std::isnan( old_prob ) );
+							      assert( !std::isnan( new_rate ) );
+							      assert( !std::isnan( old_rate ) );
+							      assert( !std::isnan( _gaussian.cdf( new_pmf.sample_ceil( new_rate ) - old_rate ) ) );
+							      assert( !std::isnan( _gaussian.cdf( new_pmf.sample_floor( new_rate ) - old_rate ) ) );
 
 							      assert( contribution >= 0.0 );
 							      assert( contribution <= 1.0 );


### PR DESCRIPTION
This is necessary for successful compilation on OS X Yosemite, with its new fancy C++11 compiler, and multiple new versions of isanan included in namespace Std.
