### PR TITLE
sproutbt2.cc: server can accept a port to listen

### DIFF
--- a/src/examples/sproutbt2.cc
+++ b/src/examples/sproutbt2.cc
@@ -18,7 +18,7 @@ int main( int argc, char *argv[] )
 
   bool server = true;
 
-  if ( argc > 1 ) {
+  if ( argc > 2 ) {
     /* client */
 
     server = false;
@@ -27,6 +27,10 @@ int main( int argc, char *argv[] )
     port = atoi( argv[ 2 ] );
 
     net = new Network::SproutConnection( "4h/Td1v//4jkYhqhLGgegw", ip, port );
+  } else if ( argc == 2 ) {
+    net = new Network::SproutConnection( NULL, argv[ 1 ] );
+
+    printf( "Listening on port: %d\n", net->port() );
   } else {
     net = new Network::SproutConnection( NULL, NULL );
 


### PR DESCRIPTION
It allows Pantheon wrapper to assign an open port to Sprout.